### PR TITLE
docs: updated activation metadata value length

### DIFF
--- a/src/Cryptlex.LexActivator/LexActivator.cs
+++ b/src/Cryptlex.LexActivator/LexActivator.cs
@@ -315,7 +315,7 @@ namespace Cryptlex
         /// in dashboard.
         /// </summary>
         /// <param name="key">string of maximum length 256 characters with utf-8 encoding</param>
-        /// <param name="value">string of maximum length 256 characters with utf-8 encoding</param>
+        /// <param name="value">string of maximum length 4096 characters with utf-8 encoding</param>
         public static void SetActivationMetadata(string key, string value)
         {
             int status;
@@ -340,7 +340,7 @@ namespace Cryptlex
         /// in dashboard.
         /// </summary>
         /// <param name="key">string of maximum length 256 characters with utf-8 encoding</param>
-        /// <param name="value">string of maximum length 256 characters with utf-8 encoding</param>
+        /// <param name="value">string of maximum length 4096 characters with utf-8 encoding</param>
         public static void SetTrialActivationMetadata(string key, string value)
         {
             int status;


### PR DESCRIPTION
## **Type**
documentation, enhancement


___

## **Description**
- Updated the `SetActivationMetadata` and `SetTrialActivationMetadata` methods documentation to specify the new maximum length of 4096 characters for the `value` parameter, enhancing the library's capability to handle larger metadata values.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LexActivator.cs</strong><dd><code>Update Activation Metadata Value Length Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
src/Cryptlex.LexActivator/LexActivator.cs

<li>Updated the documentation for <code>SetActivationMetadata</code> and <br><code>SetTrialActivationMetadata</code> methods to reflect the new maximum length <br>of 4096 characters for the <code>value</code> parameter.<br>


</details>
    

  </td>
  <td><a href="https://github.com/cryptlex/lexactivator-dotnet/pull/29/files#diff-cc131c5567d3a857b7fa1818d9d0061acc6cb9f6a1a2061c185b9d2c5e4f1447">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

